### PR TITLE
auto detect function name from require or import

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -49,6 +49,7 @@ program
   .command('lint [files...]')
   .description('find message patterns in files and verify there are no obvious problems')
   .option('-n, --function-name [name]', 'find function calls with this name [formatMessage]', 'formatMessage')
+  .option('--no-auto', 'disables auto-detecting the function name from import or require calls')
   .option('-k, --key-type [type]',
     'derived key from source pattern literal|normalized|underscored|underscored_crc32 [underscored_crc32]',
     'underscored_crc32'
@@ -87,6 +88,7 @@ program
     addStdinToFiles(files, options, () => {
       Inliner.lintFiles(files, {
         functionName: options.functionName,
+        autoDetectFunctionName: options.auto,
         translations: options.translations,
         keyType: options.keyType
       })
@@ -101,6 +103,7 @@ program
   .command('extract [files...]')
   .description('find and list all message patterns in files')
   .option('-n, --function-name [name]', 'find function calls with this name [formatMessage]', 'formatMessage')
+  .option('--no-auto', 'disables auto-detecting the function name from import or require calls')
   .option('-k, --key-type [type]',
     'derived key from source pattern (literal | normalized | underscored | underscored_crc32) [underscored_crc32]',
     'underscored_crc32'
@@ -124,6 +127,7 @@ program
     addStdinToFiles(files, options, () => {
       Inliner.extractFromFiles(files, {
         functionName: options.functionName,
+        autoDetectFunctionName: options.auto,
         locale: options.locale,
         keyType: options.keyType,
         outFile: options.outFile
@@ -140,6 +144,7 @@ program
   .alias('translate')
   .description('find and replace message pattern calls in files with translations')
   .option('-n, --function-name [name]', 'find function calls with this name [formatMessage]', 'formatMessage')
+  .option('--no-auto', 'disables auto-detecting the function name from import or require calls')
   .option('-k, --key-type [type]',
     'derived key from source pattern (literal | normalized | underscored | underscored_crc32) [underscored_crc32]',
     'underscored_crc32'
@@ -190,6 +195,7 @@ program
     addStdinToFiles(files, options, () => {
       Inliner.inlineFiles(files, {
         functionName: options.functionName,
+        autoDetectFunctionName: options.auto,
         locale: options.locale,
         keyType: options.keyType,
         translations: options.translations,

--- a/test/extract.cli.spec.js
+++ b/test/extract.cli.spec.js
@@ -201,4 +201,64 @@ describe('format-message extract', () => {
       })
     })
   })
+
+  describe('autodetect function name', () => {
+    it('finds function name from require call', done => {
+      const input = 'var f=require("format-message");f("hello")'
+      exec('bin/format-message extract', (err, stdout, stderr) => {
+        stdout = stdout.toString('utf8')
+        const translations = JSON.parse(stdout)
+        expect(translations.en).to.eql({
+          hello_32e420db: 'hello'
+        })
+        expect(stderr.toString('utf8')).to.equal('')
+        done(err)
+      }).stdin.end(input, 'utf8')
+    })
+
+    it('handles multiple function names in function context', done => {
+      const input = `
+        function foo(){
+          var f=require("format-message");
+          f("hello")
+        }
+        function bar(){
+          formatMessage("bye")
+        }`
+      exec('bin/format-message extract', (err, stdout, stderr) => {
+        stdout = stdout.toString('utf8')
+        const translations = JSON.parse(stdout)
+        expect(translations.en).to.eql({
+          bye_374365a8: 'bye',
+          hello_32e420db: 'hello'
+        })
+        expect(stderr.toString('utf8')).to.equal('')
+        done(err)
+      }).stdin.end(input, 'utf8')
+    })
+
+    it('finds function name from import', done => {
+      const input = 'import __ from "format-message";__("hello")'
+      exec('bin/format-message extract', (err, stdout, stderr) => {
+        stdout = stdout.toString('utf8')
+        const translations = JSON.parse(stdout)
+        expect(translations.en).to.eql({
+          hello_32e420db: 'hello'
+        })
+        expect(stderr.toString('utf8')).to.equal('')
+        done(err)
+      }).stdin.end(input, 'utf8')
+    })
+
+    it('is disabled by --no-auto', done => {
+      const input = 'import __ from "format-message";__("hello")'
+      exec('bin/format-message extract --no-auto', (err, stdout, stderr) => {
+        stdout = stdout.toString('utf8')
+        const translations = JSON.parse(stdout)
+        expect(translations.en).to.eql({})
+        expect(stderr.toString('utf8')).to.equal('')
+        done(err)
+      }).stdin.end(input, 'utf8')
+    })
+  })
 })

--- a/test/inline.cli.spec.js
+++ b/test/inline.cli.spec.js
@@ -289,4 +289,50 @@ describe('format-message inline', () => {
       })
     })
   })
+
+  describe('autodetect function name', () => {
+    it('finds function name from require call', done => {
+      const input = 'var f=require("format-message");f("hello")'
+      exec('bin/format-message inline', (err, stdout, stderr) => {
+        expect(stderr.toString('utf8')).to.equal('')
+        expect(stdout.toString('utf8')).to.not.contain('f(')
+        done(err)
+      }).stdin.end(input, 'utf8')
+    })
+
+    it('handles multiple function names in function context', done => {
+      const input = `
+        function foo(){
+          var f=require("format-message");
+          f("hello")
+        }
+        function bar(){
+          formatMessage("bye")
+        }`
+      exec('bin/format-message inline', (err, stdout, stderr) => {
+        expect(stderr.toString('utf8')).to.equal('')
+        expect(stdout.toString('utf8')).to.not.contain('f(')
+        expect(stdout.toString('utf8')).to.not.contain('formatMessage(')
+        done(err)
+      }).stdin.end(input, 'utf8')
+    })
+
+    it('finds function name from import', done => {
+      const input = 'import __ from "format-message";__("hello")'
+      exec('bin/format-message inline', (err, stdout, stderr) => {
+        expect(stderr.toString('utf8')).to.equal('')
+        expect(stdout.toString('utf8')).to.not.contain('__(')
+        done(err)
+      }).stdin.end(input, 'utf8')
+    })
+
+    it('is disabled by --no-auto', done => {
+      const input = 'import __ from "format-message";__("hello")'
+      exec('bin/format-message inline --no-auto', (err, stdout, stderr) => {
+        expect(stderr.toString('utf8')).to.equal('')
+        expect(stdout.toString('utf8')).to.contain('__(')
+        done(err)
+      }).stdin.end(input, 'utf8')
+    })
+  })
 })


### PR DESCRIPTION
If the code follows common convention of including one of the following lines before code that uses the function, the function name is auto-detected:

```js
import formatMessage from 'format-message' // ES 2015 module import
var __ = require('format-message') // CommonJS require
var format = _interopRequire(require('format-message')) // require via babel or other transpiler
```

This does only rudimentary scoping though. If an `import` or `require` happens inside a `Program` (file) or a `Function`, the new name is used for the rest of the body of that `Program` or `Function` only, and afterwards resets.

Reassigning to a new variable will not be tracked, only a variable declared and initialized with `require`, or an `import [id] from ...` will update the function name.

p.s. The require wrapping function name doesn't matter. It doesn't have to be `_interopRequire`.