### PR TITLE
Refactor and add more options and optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,18 +254,20 @@ find and replace message pattern calls in files with translations
 
 #### Options:
 
-    -h, --help                  output usage information
-    -n, --function-name [name]  find function calls with this name [formatMessage]
-    --no-auto                   disables auto-detecting the function name from import or require calls
-    -k, --key-type [type]       derived key from source pattern (literal | normalized | underscored | underscored_crc32) [underscored_crc32]
-    -l, --locale [locale]       BCP 47 language tags specifying the target locale [en]
-    -t, --translations [path]   location of the JSON file with message translations
-    -i, --source-maps-inline    append sourceMappingURL comment to bottom of code
-    -s, --source-maps           save source map alongside the compiled code
-    -f, --filename [filename]   filename to use when reading from stdin - this will be used in source-maps, errors etc [stdin]
-    -o, --out-file [out]        compile all input files into a single file
-    -d, --out-dir [out]         compile an input directory of modules into an output directory
-    -r, --root [path]           remove root path for source filename in output directory [cwd]
+    -h, --help                            output usage information
+    -n, --function-name [name]            find function calls with this name [formatMessage]
+    --no-auto                             disables auto-detecting the function name from import or require calls
+    -k, --key-type [type]                 derived key from source pattern (literal | normalized | underscored | underscored_crc32) [underscored_crc32]
+    -l, --locale [locale]                 BCP 47 language tags specifying the target locale [en]
+    -t, --translations [path]             location of the JSON file with message translations
+    -e, --missing-translation [behavior]  behavior when --translations is specified, but a translated pattern is missing (error | warning | ignore) [error]
+    -m, --missing-replacement [pattern]   pattern to inline when a translated pattern is missing, defaults to the source pattern
+    -i, --source-maps-inline              append sourceMappingURL comment to bottom of code
+    -s, --source-maps                     save source map alongside the compiled code
+    -f, --filename [filename]             filename to use when reading from stdin - this will be used in source-maps, errors etc [stdin]
+    -o, --out-file [out]                  compile all input files into a single file
+    -d, --out-dir [out]                   compile an input directory of modules into an output directory
+    -r, --root [path]                     remove root path for source filename in output directory [cwd]
 
 #### Examples:
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -41,6 +41,12 @@ module.exports = function (config) {
       noInfo: true
     },
 
+    client: {
+      mocha: {
+        timeout: 10000
+      }
+    },
+
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "test": "npm run lint && npm run test-setup && npm run test-node && npm run test-browsers",
     "test-browsers": "karma start --browsers Firefox,PhantomJS --single-run",
     "test-setup": "rm -rf test/inline && bin/format-message inline test/format.spec.js > test/format-inline.spec.js",
-    "test-node": "istanbul cover _mocha -- -cG -R dot -r ./test/setup test/**/*.spec.js"
+    "test-node": "istanbul cover _mocha -- -cG --timeout 10000 -R dot -r ./test/setup test/**/*.spec.js"
   },
   "standard": {
     "ignore": [

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
   "standard": {
     "ignore": [
       "lib/**",
-      "test/format-inline.spec.js"
+      "test/format-inline.spec.js",
+      "scripts/benchmark.js"
     ]
   },
   "repository": {

--- a/scripts/benchmark.src.js
+++ b/scripts/benchmark.src.js
@@ -39,13 +39,12 @@ benchmark(
 pattern = 'Simple string with { placeholder }.'
 intlMF = new IntlMF(pattern, 'en-US').format
 mf = new MessageFormat(pattern, 'en-US').format
-args = { placeholder: 'replaced value' }
 benchmark(
   'Format common one arg message', {
-    'intl-messageformat (reuse object)': () => intlMF(args),
-    'message-format (reuse object)': () => mf(args),
-    'format': () => formatMessage(pattern, args, 'en-US'),
-    'format (transpiled)': () => formatMessage('Simple string with { placeholder }.', args, 'en-US')
+    'intl-messageformat (reuse object)': () => intlMF({ placeholder: 'replaced value' }),
+    'message-format (reuse object)': () => mf({ placeholder: 'replaced value' }),
+    'format': () => formatMessage(pattern, { placeholder: 'replaced value' }, 'en-US'),
+    'format (transpiled)': () => formatMessage('Simple string with { placeholder }.', { placeholder: 'replaced value' }, 'en-US')
   }
 )
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -151,6 +151,11 @@ program
   )
   .option('-l, --locale [locale]', 'BCP 47 language tags specifying the target locale [en]', 'en')
   .option('-t, --translations [path]', 'location of the JSON file with message translations')
+  .option('-e, --missing-translation [behavior]',
+    'behavior when --translations is specified, but a translated pattern is missing (error | warning | ignore) [error]',
+    'error'
+  )
+  .option('-m, --missing-replacement [pattern]', 'pattern to inline when a translated pattern is missing, defaults to the source pattern')
   .option('-i, --source-maps-inline', 'append sourceMappingURL comment to bottom of code')
   .option('-s, --source-maps', 'save source map alongside the compiled code')
   .option('-f, --filename [filename]', 'filename to use when reading from stdin - this will be used in source-maps, errors etc [stdin]', 'stdin')
@@ -187,6 +192,13 @@ program
         errors.push(err.message)
       }
     }
+    if (
+      options.missingTranslation !== 'error' &&
+      options.missingTranslation !== 'warning' &&
+      options.missingTranslation !== 'ignore'
+    ) {
+      errors.push('--missing-translation must be "error" "warning" or "ignore"')
+    }
     if (errors.length) {
       console.error(errors.join('. '))
       process.exit(2)
@@ -199,6 +211,8 @@ program
         locale: options.locale,
         keyType: options.keyType,
         translations: options.translations,
+        missingTranslation: options.missingTranslation,
+        missingReplacement: options.missingReplacement,
         sourceMaps: options.sourceMapsInline ? 'inline' : options.sourceMaps,
         outFile: options.outFile,
         outDir: options.outDir,

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,8 @@
 import program from 'commander'
 import { existsSync, readFileSync } from 'fs'
 import glob from 'glob'
+import Linter from './linter'
+import Extractor from './extractor'
 import Inliner from './inliner'
 import pkg from '../package.json'
 
@@ -86,7 +88,7 @@ program
     }
 
     addStdinToFiles(files, options, () => {
-      Inliner.lintFiles(files, {
+      Linter.lintFiles(files, {
         functionName: options.functionName,
         autoDetectFunctionName: options.auto,
         translations: options.translations,
@@ -125,7 +127,7 @@ program
     }
 
     addStdinToFiles(files, options, () => {
-      Inliner.extractFromFiles(files, {
+      Extractor.extractFromFiles(files, {
         functionName: options.functionName,
         autoDetectFunctionName: options.auto,
         locale: options.locale,

--- a/src/extractor.js
+++ b/src/extractor.js
@@ -1,0 +1,55 @@
+import Visitor from './visitor'
+import { getKeyNormalized } from './translate-util'
+
+/**
+ * Transforms source code, translating and inlining `formatMessage` calls
+ **/
+export default class Extractor extends Visitor {
+
+  constructor (options) {
+    super(options)
+    this.patterns = null
+  }
+
+  extract ({ sourceCode, sourceFileName }) {
+    this.patterns = {}
+    this.run({ sourceCode, sourceFileName })
+    return this.patterns
+  }
+
+  visitFormatCall (path, traverser) {
+    traverser.traverse(path) // pre-travserse children
+    if (!this.isReplaceable(path)) return
+
+    const pattern = this.getStringValue(path.node.arguments[0])
+    const error = this.getPatternError(pattern)
+    if (error) {
+      this.reportError(path, 'SyntaxError: pattern is invalid', error.message)
+    } else {
+      const key = this.getKey(pattern)
+      this.patterns[key] = getKeyNormalized(pattern)
+    }
+  }
+
+  static extract (source, options) {
+    return new Extractor(options).extract(source)
+  }
+
+  static extractFromFiles (files, options) {
+    const extractor = new Extractor(options)
+    const translations = {}
+    extractor.forEachFile(files, source => {
+      const patterns = extractor.extract(source)
+      Object.assign(translations, patterns)
+    })
+    const json = JSON.stringify({
+      [extractor.locale]: translations
+    }, null, '  ')
+    if (options.outFile) {
+      extractor.emitFile(options.outFile, json)
+    } else {
+      extractor.emitResult(json)
+    }
+  }
+
+}

--- a/src/inliner.js
+++ b/src/inliner.js
@@ -47,7 +47,7 @@ export default class Inliner extends Visitor {
     // body[0] should be an ExpressionStatement, so its expresion is what we want
     const codeAst = recast.parse(replacement).program.body[0].expression
     if (codeAst.type === CallExpression) {
-      codeAst.arguments = [ paramsNode ]
+      codeAst.arguments[1] = paramsNode
     }
     path.replace(codeAst)
   }

--- a/src/inliner.js
+++ b/src/inliner.js
@@ -34,7 +34,7 @@ export default class Inliner extends Visitor {
 
     const node = path.node
     const locale = node.arguments[2] && this.getStringValue(node.arguments[2]) || this.locale
-    const params = node.arguments[1] || builders.literal(null)
+    const paramsNode = node.arguments[1] || builders.literal(null)
     const functionName = this.functionName
     const originalPattern = this.getStringValue(node.arguments[0])
     let pattern = this.translate(originalPattern, locale)
@@ -42,12 +42,12 @@ export default class Inliner extends Visitor {
       pattern = this.handleMissingTranslation(originalPattern, locale, path)
     }
     const patternAst = Parser.parse(pattern)
-    const { replacement, declaration } = Transpiler.transpile(patternAst, { locale, functionName, params, originalPattern })
+    const { replacement, declaration } = Transpiler.transpile(patternAst, { locale, functionName, paramsNode, originalPattern })
     this.addDeclaration(declaration)
     // body[0] should be an ExpressionStatement, so its expresion is what we want
     const codeAst = recast.parse(replacement).program.body[0].expression
     if (codeAst.type === CallExpression) {
-      codeAst.arguments = [ params ]
+      codeAst.arguments = [ paramsNode ]
     }
     path.replace(codeAst)
   }

--- a/src/linter.js
+++ b/src/linter.js
@@ -1,0 +1,72 @@
+import Visitor from './visitor'
+
+export default class Linter extends Visitor {
+
+  constructor (options) {
+    super(options)
+  }
+
+  lint ({ sourceCode, sourceFileName }) {
+    this.run({ sourceCode, sourceFileName })
+  }
+
+  visitFormatCall (path, traverser) {
+    traverser.traverse(path) // pre-travserse children
+
+    const node = path.node
+    let error
+    let numErrors = 0
+    if (!this.isString(node.arguments[0])) {
+      this.reportWarning(path, 'Warning: called without a literal pattern')
+      ++numErrors
+    }
+    if (node.arguments[2] && !this.isString(node.arguments[2])) {
+      this.reportWarning(path, 'Warning: called with a non-literal locale')
+      ++numErrors
+    }
+
+    if (
+      this.isString(node.arguments[0])
+      && (error = this.getPatternError(this.getStringValue(node.arguments[0])))
+    ) {
+      this.reportError(path, 'SyntaxError: pattern is invalid', error.message)
+      return ++numErrors // can't continue validating pattern
+    }
+
+    if (this.isReplaceable(path) && this.translations) {
+      const locale = node.arguments[2] ?
+        this.getStringValue(node.arguments[2]) :
+        this.locale
+      const pattern = this.getStringValue(node.arguments[0])
+      const translation = this.translate(pattern, locale)
+      if (translation == null) {
+        this.reportWarning(
+          path,
+          'Warning: no ' + locale + ' translation found for key ' +
+            JSON.stringify(this.getKey(pattern))
+        )
+        ++numErrors
+      } else if ((error = this.getPatternError(translation))) {
+        this.reportError(
+          path,
+          'SyntaxError: ' + locale + ' translated pattern is invalid for key ' +
+            JSON.stringify(this.getKey(pattern)),
+          error.message
+        )
+        ++numErrors
+      }
+    }
+
+    return numErrors
+  }
+
+  static lint (source, options) {
+    return new Linter(options).lint(source)
+  }
+
+  static lintFiles (files, options) {
+    const linter = new Linter(options)
+    linter.forEachFile(files, source => linter.lint(source))
+  }
+
+}

--- a/src/transpiler.js
+++ b/src/transpiler.js
@@ -84,8 +84,8 @@ class Transpiler {
     const vars = Object.keys(this.vars)
     const key = this.originalPattern || elements.join(' ')
     const functionName = '$$_' + getKeyUnderscoredCrc32(key)
-    const replacement = functionName + '(args)' // args needs to be swapped by consumer
-    const declaration = 'function ' + functionName + ' (args) {\n' +
+    const replacement = functionName + '(' + this.functionName + ', args)' // args needs to be swapped by consumer
+    const declaration = 'function ' + functionName + ' (' + this.functionName + ', args) {\n' +
       (!vars.length ? '' : '  var ' + vars.join(', ') + ';\n') +
       '  return ' + elements.join(' + ') +
     ';\n}'

--- a/src/visitor.js
+++ b/src/visitor.js
@@ -1,0 +1,248 @@
+import { readFileSync, writeFileSync } from 'fs'
+import { relative, resolve, dirname, basename, join as pathJoin } from 'path'
+import mkdirp from 'mkdirp'
+import recast from 'recast'
+import sourceMap from 'source-map'
+import chalk from 'chalk'
+import Parser from 'message-format/parser'
+import { getTranslate, getGetKey, getKeyNormalized, getKeyUnderscoredCrc32 } from './translate-util'
+import Transpiler from './transpiler'
+import packageJson from '../package.json'
+const Literal = recast.types.namedTypes.Literal.toString()
+const TemplateLiteral = recast.types.namedTypes.TemplateLiteral.toString()
+const CallExpression = recast.types.namedTypes.CallExpression.toString()
+const ImportDefaultSpecifier = recast.types.namedTypes.ImportDefaultSpecifier.toString()
+
+/**
+ * Base class for traversing source code to lint, extract, and inline messages
+ **/
+export default class Visitor {
+
+  constructor (options={}) {
+    this.functionName = options.functionName || 'formatMessage'
+    this.autoDetectFunctionName = 'autoDetectFunctionName' in options ?
+      !!options.autoDetectFunctionName : true
+    this.getKey = getGetKey(options)
+    this.translate = getTranslate(options)
+    this.translations = options.translations
+    this.missingTranslation = options.missingTranslation
+    this.missingReplacement = options.missingReplacement
+    this.locale = options.locale || 'en'
+    this.currentFileName = null
+
+    if (typeof options.emitWarning === 'function') {
+      this.emitWarning = options.emitWarning
+    }
+    if (typeof options.emitError === 'function') {
+      this.emitError = options.emitError
+    }
+    if (typeof options.emitResult === 'function') {
+      this.emitResult = options.emitResult
+    }
+    if (typeof options.emitFile === 'function') {
+      this.emitFile = options.emitFile
+    }
+  }
+
+  emitWarning (message) {
+    console.warn(message)
+  }
+
+  emitError (message) {
+    console.error(message)
+  }
+
+  emitResult (code) {
+    console.log(code)
+  }
+
+  emitFile (filename, content, sourcemap) {
+    mkdirp.sync(dirname(filename))
+    writeFileSync(filename, content, 'utf8')
+  }
+
+  reportWarning (path, message) {
+    this.emitWarning(
+      chalk.bold.yellow(message) + '\n' +
+      chalk.yellow(this.getLocation(path))
+    )
+  }
+
+  reportError (path, message, submessage) {
+    this.emitError(
+      chalk.red(
+        chalk.bold(message) + '\n' +
+        this.getLocation(path) +
+        (!submessage ? '' :
+          '\n    ' + submessage.replace(/\n/g, '\n    ')
+        )
+      )
+    )
+  }
+
+  getLocation (path) {
+    return (
+      '    at ' + this.functionName + ' (' +
+      this.currentFileName + ':' +
+      path.node.loc.start.line + ':' +
+      path.node.loc.start.column + ')'
+    )
+  }
+
+  isFormatImport (node) {
+    return node && (
+      node.source
+      && node.source.value === packageJson.name
+      && node.specifiers
+      && node.specifiers[0]
+      && node.specifiers[0].type === ImportDefaultSpecifier
+    )
+  }
+
+  isFormatRequire (node, depth=0) {
+    return node && (
+      node.type === CallExpression
+      && node.callee.name === 'require'
+      && this.isString(node.arguments[0])
+      && this.getStringValue(node.arguments[0]) === packageJson.name
+    ) || node && (
+      // _interopRequire or other wrapper
+      node.type === CallExpression
+      && depth <= 1 // allow at most one wrapper around require
+      && this.isFormatRequire(node.arguments[0], depth + 1)
+    )
+  }
+
+  isFormatCall (path) {
+    const node = path.node
+    return (
+      node.callee.name === this.functionName
+    )
+  }
+
+  isReplaceable (path) {
+    const node = path.node
+    return node && (
+      this.isFormatCall(path)
+      // first argument is a literal string, or template literal with no expressions
+      && this.isString(node.arguments[0])
+      && (
+        // no specified locale, or is a literal string
+        !node.arguments[2]
+        || this.isString(node.arguments[2])
+      )
+    )
+  }
+
+  isString (node) {
+    return node && (
+      node.type === Literal
+      && typeof node.value === 'string'
+      || (
+        node.type === TemplateLiteral
+        && node.expressions.length === 0
+        && node.quasis.length === 1
+      )
+    )
+  }
+
+  getStringValue (literal) {
+    if (literal.type === TemplateLiteral) {
+      return literal.quasis[0].value.cooked
+    }
+    return literal.value
+  }
+
+  getPatternError (pattern) {
+    try {
+      Parser.parse(pattern)
+    } catch (error) {
+      return error
+    }
+  }
+
+  forEachFile (files, fn, ctx) {
+    for (let file of files) {
+      let source = file
+      if (typeof file === 'string') {
+        source = {
+          sourceFileName: file,
+          sourceCode: readFileSync(file, 'utf8')
+        }
+      }
+      fn.call(ctx, source)
+    }
+  }
+
+  run ({ sourceCode, sourceFileName }) {
+    const ast = this.parse({ sourceCode, sourceFileName })
+    if (ast) {
+      const self = this
+      recast.visit(ast, this.visitors({
+        visitCallExpression (path) {
+          if (self.isFormatCall(path)) {
+            self.visitFormatCall(path, this)
+          } else {
+            this.traverse(path)
+          }
+        }
+      }))
+    }
+    return ast
+  }
+
+  parse ({ sourceCode, sourceFileName }) {
+    this.currentFileName = sourceFileName
+    try {
+      return recast.parse(sourceCode, { sourceFileName })
+    } catch (error) {
+      this.emitError(
+        chalk.red(
+          chalk.bold('SyntaxError: Could not parse source code') + '\n' +
+          '    at ' + sourceFileName + '\n' +
+          '    ' + error.message
+        )
+      )
+    }
+  }
+
+  print ({ ast, sourceMapName, inputSourceMap }) {
+    return recast.print(ast, { sourceMapName, inputSourceMap })
+  }
+
+  visitors (base) {
+    if (this.autoDetectFunctionName) {
+      const self = this
+      Object.assign(base, {
+        // simplistic function and file scope tracking
+        visitFunction (path) {
+          const functionName = self.functionName
+          this.traverse(path) // traverse children
+          self.functionName = functionName
+        },
+
+        visitProgram (path) {
+          const functionName = self.functionName
+          this.traverse(path) // traverse children
+          self.functionName = functionName
+        },
+
+        visitVariableDeclarator (path) {
+          this.traverse(path) // pre-travserse children
+          if (self.isFormatRequire(path.node.init)) {
+            self.functionName = path.node.id.name
+          }
+        },
+
+        visitImportDeclaration (path) {
+          this.traverse(path) // pre-travserse children
+          if (self.isFormatImport(path.node)) {
+            self.functionName = path.node.specifiers[0].id.name
+          }
+        }
+      })
+    }
+    return base
+  }
+
+}

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -17,14 +17,16 @@ describe('formatMessage', () => {
     })
 
     it('accepts arguments', () => {
-      const message = formatMessage('x{ arg }z', { arg: 'y' })
+      const arg = 'y'
+      const message = formatMessage('x{ arg }z', { arg })
       expect(message).to.equal('xyz')
     })
 
     it('formats numbers, dates, and times', () => {
+      const d = new Date(0)
       const message = formatMessage(
         '{ n, number } : { d, date, short } { d, time, short }',
-        { n: 0, d: new Date(0) }
+        { n: 0, d }
       )
       expect(message).to.match(/^0 \: \d\d?\/\d\d?\/\d{2,4} \d\d?\:\d\d [AP]M$/)
     })

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -1,6 +1,6 @@
 /*eslint-env mocha */
+if (typeof Intl === 'undefined') { require('intl') }
 import { expect } from 'chai'
-if (typeof Intl === 'undefined') { require('intl') } // include polyfll for Safari and PhantomJS
 import MessageFormat from 'message-format'
 import formatMessage from '../src/format-message'
 
@@ -28,7 +28,7 @@ describe('formatMessage', () => {
         '{ n, number } : { d, date, short } { d, time, short }',
         { n: 0, d }
       )
-      expect(message).to.match(/^0 \: \d\d?\/\d\d?\/\d{2,4} \d\d?\:\d\d [AP]M$/)
+      expect(message).to.match(/^0 \: \d\d?\/\d\d?\/\d{2,4} \d\d?\:\d\d/)
     })
 
     it('handles plurals', () => {

--- a/test/inline.cli.spec.js
+++ b/test/inline.cli.spec.js
@@ -249,7 +249,7 @@ describe('format-message inline', () => {
           'setup.js'
         ].sort())
         const fileContent = readFileSync(dirname + '/format.spec.js', 'utf8')
-        expect(fileContent.trim()).to.contain('"x" + args["arg"] + "z"')
+        expect(fileContent.trim()).to.contain('"x" + arg + "z"')
         done(err)
       })
     })
@@ -281,7 +281,7 @@ describe('format-message inline', () => {
         const fileContent =
           readFileSync(dirname + '/format.spec.js', 'utf8')
           .split('\/\/# sourceMappingURL=')
-        expect(fileContent[0].trim()).to.contain('"x" + args["arg"] + "z"')
+        expect(fileContent[0].trim()).to.contain('"x" + arg + "z"')
         expect((fileContent[1] || '').trim()).to.equal('format.spec.js.map')
         const sourceMap = readFileSync(dirname + '/format.spec.js.map', 'utf8')
         expect(JSON.parse(sourceMap)).to.not.be.empty

--- a/test/inline.cli.spec.js
+++ b/test/inline.cli.spec.js
@@ -146,6 +146,70 @@ describe('format-message inline', () => {
         }).stdin.end(input, 'utf8')
       })
     })
+
+    describe('missing-translation', () => {
+      it('causes a fatal error by default', done => {
+        const input = 'formatMessage("not translated")'
+        const cmd = 'bin/format-message inline' +
+          ' -t test/translations/inline.underscored_crc32.json'
+        exec(cmd, (err, stdout, stderr) => {
+          expect(err).to.exist
+          expect(stdout.toString('utf8')).to.equal('')
+          expect(stderr.toString('utf8')).to.match(/^Error: no en translation found/)
+          done()
+        }).stdin.end(input, 'utf8')
+      })
+
+      it('can trigger a non-fatal warning instead with -e warning ', done => {
+        const input = 'formatMessage("not translated")'
+        const cmd = 'bin/format-message inline' +
+          ' -e warning' +
+          ' -t test/translations/inline.underscored_crc32.json'
+        exec(cmd, (err, stdout, stderr) => {
+          expect(stderr.toString('utf8')).to.match(/^Warning: no en translation found/)
+          expect(stdout.toString('utf8').trim()).to.equal('"not translated"')
+          done(err)
+        }).stdin.end(input, 'utf8')
+      })
+
+      it('can be ignored with --missing-translation ignore', done => {
+        const input = 'formatMessage("not translated")'
+        const cmd = 'bin/format-message inline' +
+          ' --missing-translation ignore' +
+          ' -t test/translations/inline.underscored_crc32.json'
+        exec(cmd, (err, stdout, stderr) => {
+          expect(stderr.toString('utf8')).to.equal('')
+          expect(stdout.toString('utf8').trim()).to.equal('"not translated"')
+          done(err)
+        }).stdin.end(input, 'utf8')
+      })
+
+      it('can be replaced with -m replacement', done => {
+        const input = 'formatMessage("not translated")'
+        const cmd = 'bin/format-message inline' +
+          ' -e ignore' +
+          ' -m "!!MISSING!!"' +
+          ' -t test/translations/inline.underscored_crc32.json'
+        exec(cmd, (err, stdout, stderr) => {
+          expect(stderr.toString('utf8')).to.equal('')
+          expect(stdout.toString('utf8').trim()).to.equal('"!!MISSING!!"')
+          done(err)
+        }).stdin.end(input, 'utf8')
+      })
+
+      it('can be replaced with --missing-replacement', done => {
+        const input = 'formatMessage("not translated")'
+        const cmd = 'bin/format-message inline' +
+          ' -e ignore' +
+          ' --missing-replacement "!!MISSING!!"' +
+          ' -t test/translations/inline.underscored_crc32.json'
+        exec(cmd, (err, stdout, stderr) => {
+          expect(stderr.toString('utf8')).to.equal('')
+          expect(stdout.toString('utf8').trim()).to.equal('"!!MISSING!!"')
+          done(err)
+        }).stdin.end(input, 'utf8')
+      })
+    })
   })
 
   describe('source-maps-inline', () => {


### PR DESCRIPTION
* Separates linter and extractor from inliner
* Cleans up message-format.js
* Adds missing translation options (fixes #4)
* Ensures `formatMessage` is in scope in declarations (fixes #7)
