### PR TITLE
add formatMessage.translate

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,20 @@ Parameters
         - `pattern` is the message pattern to translate.
         - `locale` is a string with a BCP 47 language tag, or an array of such strings.
 
+### `formatMessage.translate`
+
+```js
+formatMessage.translate(pattern[, locales])
+```
+
+Use the currently configured `translate` to get the locale-specific pattern. Note that this can also be linted, extracted, and inlined if the `pattern` is a literal.
+
+Parameters
+
+- `pattern` is a properly formatted ICU Message Format pattern.
+- `locales` is an optional string with a BCP 47 language tag, or an array of such strings.
+  - If not specified, the currently configured `locale` will be used.
+
 ### internal apis
 
 `formatMessage.number`, `formatMessage.date`, and `formatMessage.time` are used internally and are not intended for external use. Because these appear in the transpiled code, transpiling does not remove the need to properly define `formatMessage` through `require` or `import`.

--- a/src/format-message.js
+++ b/src/format-message.js
@@ -25,6 +25,11 @@ export default function formatMessage (pattern, args, locale) {
   )(args)
 }
 
+formatMessage.translate = function (pattern, locale) {
+  locale = locale || currentLocale
+  return currentTranslate(pattern, locale)
+}
+
 formatMessage.setup = function ({ cache, locale, translate }={}) {
   if (typeof cache === 'boolean') enableCache = cache
   if (locale) currentLocale = locale

--- a/test/extract.cli.spec.js
+++ b/test/extract.cli.spec.js
@@ -31,6 +31,19 @@ describe('format-message extract', () => {
       }).stdin.end(input, 'utf8')
     })
 
+    it('finds and extracts from translate calls', done => {
+      const input = 'formatMessage.translate("hello")'
+      exec('bin/format-message extract', (err, stdout, stderr) => {
+        stdout = stdout.toString('utf8')
+        const translations = JSON.parse(stdout)
+        expect(translations.en).to.eql({
+          hello_32e420db: 'hello'
+        })
+        expect(stderr.toString('utf8')).to.equal('')
+        done(err)
+      }).stdin.end(input, 'utf8')
+    })
+
     it('dedupes repeated patterns', done => {
       const input = 'formatMessage("hello");formatMessage(`hello`)'
       exec('bin/format-message extract', (err, stdout, stderr) => {

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -143,4 +143,16 @@ describe('formatMessage', () => {
       expect(message).to.equal('test-success')
     })
   })
+
+  describe('translate', () => {
+    it('looks up the translated pattern', () => {
+      formatMessage.setup({ translate (pattern) { return 'translated' } })
+      // use variable to avoid inlining
+      const originalPattern = 'trans-test'
+      const pattern = formatMessage.translate(originalPattern)
+      formatMessage.setup({ translate (pattern) { return pattern } })
+
+      expect(pattern).to.equal('translated')
+    })
+  })
 })

--- a/test/inline.cli.spec.js
+++ b/test/inline.cli.spec.js
@@ -23,6 +23,15 @@ describe('format-message inline', () => {
       }).stdin.end(input, 'utf8')
     })
 
+    it('finds and replaces translate calls', done => {
+      const input = 'formatMessage.translate("hello { name }")'
+      exec('bin/format-message inline', (err, stdout, stderr) => {
+        expect(stderr.toString('utf8')).to.equal('')
+        expect(stdout.toString('utf8').trim()).to.equal('"hello { name }"')
+        done(err)
+      }).stdin.end(input, 'utf8')
+    })
+
     it('can output to a -o file', done => {
       const input = 'formatMessage("hello")'
       const filename = 'test/translations/inline.js'

--- a/test/lint.cli.spec.js
+++ b/test/lint.cli.spec.js
@@ -22,6 +22,15 @@ describe('format-message lint', () => {
       }).stdin.end(input, 'utf8')
     })
 
+    it('reports errors in translate calls', done => {
+      const input = 'formatMessage.translate("{")'
+      exec('bin/format-message lint', (err, stdout, stderr) => {
+        expect(stdout.toString('utf8')).to.equal('')
+        expect(stderr.toString('utf8')).to.match(/^SyntaxError\:/)
+        done(err)
+      }).stdin.end(input, 'utf8')
+    })
+
     it('reports filename as "stdin" by default', done => {
       const input = 'formatMessage("{")'
       exec('bin/format-message lint', (err, stdout, stderr) => {


### PR DESCRIPTION
This is particularly useful if runtime parsing of a translated pattern is needed, for example building a complex message with html etc.